### PR TITLE
refs: #10 - updated to build 3.3.7 version of taiga BE and FE-dist

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine3.6 as BUILDER
 
-ENV TAIGA_VERSION 3.1.3
+ENV TAIGA_VERSION 3.3.7
 
 RUN apk update \
     && apk add --virtual build-dependencies \
@@ -10,12 +10,14 @@ RUN apk update \
     postgresql-dev \
     # Pillow / PIL build dependencies
     freetype-dev jpeg-dev libwebp-dev tiff-dev libpng-dev lcms2-dev \
-    openjpeg-dev zlib-dev libxslt-dev libxml2-dev libffi-dev
+    openjpeg-dev zlib-dev libxslt-dev libxml2-dev libffi-dev \
+    # Other tools
+    git
 
 WORKDIR /taiga_backend
 
 ADD https://github.com/taigaio/taiga-back/archive/${TAIGA_VERSION}.tar.gz ./
-RUN tar -xzf ${TAIGA_VERSION}.tar.gz -C ./ taiga-back-${TAIGA_VERSION} --strip-components=1
+    RUN tar -xzf ${TAIGA_VERSION}.tar.gz -C ./ taiga-back-${TAIGA_VERSION} --strip-components=1
 RUN rm ${TAIGA_VERSION}.tar.gz
 
 # Don't want pip to use git, so I'm replacing with pypi.  
@@ -35,7 +37,7 @@ RUN pip wheel --wheel-dir=./taiga_python_dependencies -r requirements.txt
 FROM python:3.6-alpine3.6
 
 LABEL maintainer="douglasmirandasilva@gmail.com"
-LABEL taiga_version="tag:3.1.3"
+LABEL taiga_version="tag:3.3.7"
 
 WORKDIR /taiga_backend
 
@@ -47,7 +49,9 @@ RUN apk add --no-cache \
     # Postgres python client
     libpq \
     # Needed for localization stuff: python manage.py compilemessages
-    gettext
+    gettext \
+    # Other tools
+    git
 
 RUN pip install --no-cache-dir --no-index --find-links=taiga_python_dependencies -r requirements.txt \
     && rm -R ./taiga_python_dependencies \

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -9,6 +9,8 @@ if [ -z "$TAIGA_SKIP_DB_CHECK" ]; then
     python /taiga_backend/manage.py migrate --noinput
     python /taiga_backend/manage.py loaddata initial_user
     python /taiga_backend/manage.py loaddata initial_project_templates
+    python /taiga_backend/manage.py compilemessages
+    python /taiga_backend/manage.py collectstatic --noinput
   fi
 fi
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,9 @@
 FROM nginx:1.13-alpine
 
 LABEL maintainer="douglasmirandasilva@gmail.com"
-LABEL taiga_version="tag:3.1.3-stable"
+LABEL taiga_version="tag:3.3.7-stable"
 
-ENV TAIGA_VERSION 3.1.3-stable
+ENV TAIGA_VERSION 3.3.7-stable
 
 COPY nginx/ /etc/nginx/conf.d/
 # Entrypoint


### PR DESCRIPTION
Updated backend and frontend Dockerfile to install 3.3.7 version of Taiga BE and FE-dist.

Tested after build and seems to work well. I have only this error in browser console

`http://mydomain.com/api/v1/user-storage/joyride 404 (Not Found)` 

but probably depends on my local.py configuration used for test (as written here: https://github.com/taigaio/taiga-back/issues/1022).

